### PR TITLE
Issue/1/docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,44 @@
+## R
+# History files
+.Rhistory
+.Rapp.history
+
+# Session Data files
+.RData
+
+# User-specific files
+.Ruserdata
+
+# Example code in package build process
+*-Ex.R
+
+# Output files from R CMD build
+/*.tar.gz
+
+# Output files from R CMD check
+/*.Rcheck/
+
+# RStudio files
+.Rproj.user/
+
+# produced vignettes
+vignettes/*.html
+vignettes/*.pdf
+
+# OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
+.httr-oauth
+
+# knitr and R markdown default cache directories
+*_cache/
+/cache/
+
+# Temporary files created by R markdown
+*.utf8.md
+*.knit.md
+
+rdodo/inst/config.yml
+
+## Python
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -20,6 +61,8 @@ parts/
 sdist/
 var/
 wheels/
+pip-wheel-metadata/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
@@ -38,6 +81,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
 .coverage.*
 .cache
@@ -55,6 +99,7 @@ coverage.xml
 *.log
 local_settings.py
 db.sqlite3
+db.sqlite3-journal
 
 # Flask stuff:
 instance/
@@ -72,8 +117,19 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# IPython
+profile_default/
+ipython_config.py
+
 # pyenv
 .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
 
 # celery beat schedule file
 celerybeat-schedule
@@ -102,3 +158,8 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - "echo $PWD"
   - "git pull --all"
   - "export SIMURGH_HOME=$PWD"
+  - "export DODO_HOME=$SIMURGH_HOME/dodo"
 
 install:
   - "bash miniconda.sh -b -p $HOME/miniconda"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ branches:
   only:
   - "master"
   - "develop"
-  - "issue/2/ci-testing"
+  - "issue/1/docker-compose"
 
 os:
   - "linux"
@@ -39,6 +39,9 @@ install:
 
 script:
   - "cd dodo/PyDodo/ && pytest -vs tests/ && cd -"
+  - "docker-compose up -d"
+  - "sleep 10"
+  - "docker-compose down"
 
 after_success:
   - "test $TRAVIS_BRANCH = \"master\" && pip install mkdocs && mkdocs build --clean && mkdocs gh-deploy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - "if [ \"$TRAVIS_OS_NAME\" = \"osx\" ]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi"
   - "echo $PWD"
   - "git pull --all"
-  - "export DODO_HOME=$PWD"
+  - "export SIMURGH_HOME=$PWD"
 
 install:
   - "bash miniconda.sh -b -p $HOME/miniconda"
@@ -34,17 +34,19 @@ install:
   - "conda info -a"
   - "source $HOME/miniconda/etc/profile.d/conda.sh"
   - "export QT_QPA_PLATFORM='offscreen'"
-  - "conda create -n p36 python=3.6"
+  - "source install.sh"
 
 script:
-  - "conda activate p36"
   - "python --version"
-  - "pip install -r $DODO_HOME/PyDodo/requirements.txt"
-  - "bash $DODO_HOME/PyDodo/tests/travis.sh"
+  - "pip install -r $SIMURGH_HOME/dodo/PyDodo/requirements.txt"
+  - "bash $SIMURGH_HOME/dodo/PyDodo/tests/travis.sh"
   - "conda install r-base"
   - "conda install r-essentials"
   - "conda install r-devtools"
   - "conda install r-config"
   - "conda install r-testthat"
   - "conda install -c conda-forge r-future"
-  - "R CMD check --no-build-vignettes --no-manual $DODO_HOME/rdodo"
+  - "R CMD check --no-build-vignettes --no-manual $SIMURGH_HOME/dodo/rdodo"
+
+-after_success:
+-  - "test $TRAVIS_BRANCH = \"master\" && pip install mkdocs && mkdocs build --clean && mkdocs gh-deploy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ script:
   - "cd dodo/PyDodo/ && pytest -vs tests/ && cd -"
   # Test docker on Linux only as docker not yet supported on macOS within travis
   - "if [ \"$TRAVIS_OS_NAME\" = \"linux\" ]; then docker-compose up -d; sleep 10; docker-compose down; fi"
+  # Run full integration tests
+  - "if [ \"$TRAVIS_OS_NAME\" = \"linux\" ]; then docker-compose up -d; cd dodo/PyDodo/ && pytest -vs tests/ && cd - ; docker-compose down; fi"
 
 after_success:
   - "test $TRAVIS_BRANCH = \"master\" && pip install mkdocs && mkdocs build --clean && mkdocs gh-deploy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,8 @@ install:
 
 script:
   - "cd dodo/PyDodo/ && pytest -vs tests/ && cd -"
-  - "docker-compose up -d"
-  - "sleep 10"
-  - "docker-compose down"
+  # Test docker on Linux only as docker not yet supported on macOS within travis
+  - "if [ \"$TRAVIS_OS_NAME\" = \"linux\" ]; then docker-compose up -d; sleep 10; docker-compose down; fi"
 
 after_success:
   - "test $TRAVIS_BRANCH = \"master\" && pip install mkdocs && mkdocs build --clean && mkdocs gh-deploy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ install:
 script:
   - "cd dodo/PyDodo/ && pytest -vs tests/ && cd -"
   # Test docker on Linux only as docker not yet supported on macOS within travis
-  - "if [ \"$TRAVIS_OS_NAME\" = \"linux\" ]; then docker-compose up -d; sleep 10; docker-compose down; fi"
+  - "if [ \"$TRAVIS_OS_NAME\" = \"linux\" ]; then docker-compose up -d; sleep 20; docker-compose down; fi"
   # Run full integration tests
-  - "if [ \"$TRAVIS_OS_NAME\" = \"linux\" ]; then docker-compose up -d; cd dodo/PyDodo/ && pytest -vs tests/ && cd - ; docker-compose down; fi"
+  - "if [ \"$TRAVIS_OS_NAME\" = \"linux\" ]; then docker-compose up -d; sleep 20; cd dodo/PyDodo/ && pytest -vs tests/ && cd - ; docker-compose down; fi"
 
 after_success:
   - "test $TRAVIS_BRANCH = \"master\" && pip install mkdocs && mkdocs build --clean && mkdocs gh-deploy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,15 @@ compiler:
 
 sudo: "require"
 
-git:
-  submodules: false
+warnings_are_errors: false
 
 before_install:
   - "if [ \"$TRAVIS_OS_NAME\" = \"linux\" ]; then sudo apt-get update -qq; sudo apt-get install libx11-xcb1; fi"
   - "if [ \"$TRAVIS_OS_NAME\" = \"linux\" ]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi"
   - "if [ \"$TRAVIS_OS_NAME\" = \"osx\" ]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi"
-  - "git submodule update --init --recursive"
   - "echo $PWD"
   - "git pull --all"
+  - "export DODO_HOME=$PWD"
 
 install:
   - "bash miniconda.sh -b -p $HOME/miniconda"
@@ -35,14 +34,17 @@ install:
   - "conda info -a"
   - "source $HOME/miniconda/etc/profile.d/conda.sh"
   - "export QT_QPA_PLATFORM='offscreen'"
-  - "source install.sh"
+  - "conda create -n p36 python=3.6"
 
 script:
-  - "cd dodo/PyDodo/ && pytest -vs tests/ && cd -"
-  # Test docker on Linux only as docker not yet supported on macOS within travis
-  - "if [ \"$TRAVIS_OS_NAME\" = \"linux\" ]; then docker-compose up -d; sleep 20; docker-compose down; fi"
-  # Run full integration tests
-  - "if [ \"$TRAVIS_OS_NAME\" = \"linux\" ]; then docker-compose up -d; sleep 20; cd dodo/PyDodo/ && pytest -vs tests/ && cd - ; docker-compose down; fi"
-
-after_success:
-  - "test $TRAVIS_BRANCH = \"master\" && pip install mkdocs && mkdocs build --clean && mkdocs gh-deploy"
+  - "conda activate p36"
+  - "python --version"
+  - "pip install -r $DODO_HOME/PyDodo/requirements.txt"
+  - "bash $DODO_HOME/PyDodo/tests/travis.sh"
+  - "conda install r-base"
+  - "conda install r-essentials"
+  - "conda install r-devtools"
+  - "conda install r-config"
+  - "conda install r-testthat"
+  - "conda install -c conda-forge r-future"
+  - "R CMD check --no-build-vignettes --no-manual $DODO_HOME/rdodo"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ elements that all work together to achieve the aims laid out above; these are:
 
 - [NATS birdhouse](https://github.com/alan-turing-institute/nats-birdhouse) - some ATC agents (currently in Python)
 
+## Quick Start
+
+If one has Docker install, perhaps the most "hassle free" option would be to run
+`docker-compose up -d` which will pull down the pre-built images from DockerHub and
+start each container in order. Then all one needs to do is go to
+`http://localhost:8080` where Twitcher will be running.
+
+_Note_: If this is the first time running this command, it may take some time to
+download and extract all the layers involved.
+
+Then to close this, running `docker-compose down` will shutdown the running
+instances.
+
+
 # Installation
 
 In order to get things up and running, it is important to emphasise the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+
+services:
+  bluesky:
+    container_name: bluesky
+    image: turinginst/bluesky:1.1.1
+    expose:
+      - 9000
+      - 9001
+  bluebird:
+    container_name: bluebird
+    depends_on:
+      - bluesky
+    image: turinginst/bluebird:1.2.0
+    ports:
+      - 5001:5001
+    environment:
+      - BS_HOST=bluesky
+  web:
+    container_name: twitcher
+    depends_on:
+      - bluebird
+    image: tallamjr/twitcher
+    command: http-server .
+    ports:
+      - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   bluesky:
     container_name: bluesky
-    image: turinginst/bluesky:1.1.1
+    image: turinginst/bluesky:1.2.2
     expose:
       - 9000
       - 9001
@@ -11,7 +11,7 @@ services:
     container_name: bluebird
     depends_on:
       - bluesky
-    image: turinginst/bluebird:1.2.0
+    image: turinginst/bluebird:1.2.1
     ports:
       - 5001:5001
     environment:
@@ -20,7 +20,7 @@ services:
     container_name: twitcher
     depends_on:
       - bluebird
-    image: tallamjr/twitcher
+    image: turinginst/twitcher:latest
     command: http-server .
     ports:
       - "8080:8080"

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,23 +31,43 @@ contains several elements that all work together to achieve the aims laid out ab
 
 - [NATS birdhouse](https://github.com/alan-turing-institute/nats-birdhouse) - some ATC agents (currently in Python)
 
+![](img/simurgh-deps.png)
+
+## Quick Start
+
 In order to get things up and running, it is important to emphasise the
 dependencies tree of the packages outlined above.
 
-![](img/simurgh-deps.png)
-
-A full step-by-step installation guide can be found [here](https://alan-turing-institute.github.io/simurgh/install) at the installation page:
-
-However, if one would like to get up and running immediately this set of
-commands will install all dependencies and start the application using Docker by
-running:
+If one has Docker install, perhaps the most "hassle free" option would be to run:
 
 ```bash
-git clone --recurse-submodules -j8 git@github.com:alan-turing-institute/simurgh.git
-source install.sh
+$$ docker-compose up -d
 ```
+which will pull down the pre-built images from DockerHub and
+start each container in order. Then all one needs to do is go to
+`http://localhost:8080` where Twitcher will be running.
 
-> TODO :: Add Docker instructions
+_Note_: If this is the first time running this command, it may take some time to
+download and extract all the layers involved.
+
+Then to close this, running:
+
+```bash
+$$ docker-compose down
+```
+will shutdown the running instances.
+
+
+Alternatively, if one would like to get up and running fairly quickly, but
+_without_ Docker, this set of commands will install all dependencies and start the application
+by running:
+
+```bash
+$$ git clone --recurse-submodules -j8 git@github.com:alan-turing-institute/simurgh.git
+$$ source install.sh
+```
 
 This will create a conda environment call `nats` and install all necessary
 dependencies required.
+
+A full step-by-step installation guide can be found [here](https://alan-turing-institute.github.io/simurgh/install) at the installation page.


### PR DESCRIPTION
Attempts to Fix #1 

By running `docker build --tag=twitcher .` (inside the `twitcher/` repo) and then
`docker tag twitcher tallamjr/twitcher:latest` followed by `docker push tallamjr/twitcher` I was able to push a pre-built image to DockerHub that I could
later use in `simurgh` (with the corresponding `docker-compose.yml` file*) to run
`docker-compose up -d`.

This seems to build fine and is tested on [travis](https://travis-ci.com/alan-turing-institute/simurgh/builds/123231565 ) on `issue/1/docker-compose` branch.

Would this be able to be built and pushed to `turinginst/twticher` aswell/instead
and then I could update the `docker-compose.yml` file to say _turinginst/twitcher_ as opposed to
_tallamjr/twitcher_ ? (I'm assuming I do not have push rights to turinginst on DockerHub)

Then it should be the case that within `simurgh`, users would just need to run:
`docker-compose up -d`, to spin up, and then `docker-compose down` to tear down.

p.s. many thanks to @rkm for pointing me to the original [docker-compose](https://github.com/alan-turing-institute/twitcher/pull/8/files) file
which helped me learn about all of this.

**TODO**: Include `dodo` as part of the complete build.

*corresponding `docker-compose.yml`:
```
version: '3'

services:
  bluesky:
    container_name: bluesky
    image: turinginst/bluesky:1.1.1
    expose:
      - 9000
      - 9001
  bluebird:
    container_name: bluebird
    depends_on:
      - bluesky
    image: turinginst/bluebird:1.2.0
    ports:
      - 5001:5001
    environment:
      - BS_HOST=bluesky
  web:
    container_name: twitcher
    depends_on:
      - bluebird
    image: tallamjr/twitcher
    command: http-server .
    ports:
      - "8080:8080"
```