### PR TITLE
Update docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     container_name: twitcher
     depends_on:
       - bluebird
-    image: turinginst/twitcher:latest
+    image: turinginst/twitcher:1.0.1
     command: http-server .
     ports:
       - "8080:8080"


### PR DESCRIPTION
The docker-compose file now explicitly names the docker images to pull (i.e., use version number instead of "latest"). This will help in future debugging should there be any issues. If new docker images are created, this file should be explicitly updated accordingly.